### PR TITLE
Streamline SPI pin handling

### DIFF
--- a/Examples/Basics/3-SDCardTest/3-SDCardTest.ino
+++ b/Examples/Basics/3-SDCardTest/3-SDCardTest.ino
@@ -27,13 +27,12 @@
 
 
 // ----------------------------
-// SD Reader pins
+// SD Reader pins (default VSPI pins)
 // ----------------------------
-
-#define SD_SCK 18
-#define SD_MISO 19
-#define SD_MOSI 23
-#define SD_CS 5
+//#define SD_SCK 18
+//#define SD_MISO 19
+//#define SD_MOSI 23
+//#define SD_CS 5
 
 // ----------------------------
 
@@ -197,10 +196,9 @@ void testFileIO(fs::FS &fs, const char * path) {
 void setup() {
   Serial.begin(115200);
 
-  SPIClass spi = SPIClass(HSPI);
-  spi.begin(SD_SCK, SD_MISO, SD_MOSI, SD_CS);
+  SPIClass spi = SPIClass(VSPI);
 
-  if (!SD.begin(SD_CS, spi, 80000000)) {
+  if (!SD.begin(SS, spi, 80000000)) {
     Serial.println("Card Mount Failed");
     return;
   }

--- a/PINS.md
+++ b/PINS.md
@@ -76,13 +76,15 @@ Note: LEDs are "active low", meaning HIGH == off, LOW == on
 |IO17|Blue LED||
 
 ## SD Card
+Uses the VSPI
+Pin names are predefined in SPI.h
 
 |Pin|Use|Note|
 |---|---|----|
-|IO5|SD_CS||
-|IO18|SD_SCK||
-|IO19|SD_MISO||
-|IO23|SD_MOSI||
+|IO5|SS||
+|IO18|SCK||
+|IO19|MISO||
+|IO23|MOSI||
 
 ## Touch Screen
 
@@ -101,6 +103,7 @@ Note: LEDs are "active low", meaning HIGH == off, LOW == on
 |IO34|||
 
 ## Display
+Uses the HSPI
 
 |Pin|Use|Note|
 |---|---|----|


### PR DESCRIPTION
SD card pin are actually the VSPI default pin, so no need to define them (the are defined as SCK, MOSI, MOSI, SS defines in SPI.h)

left the defines commented out, so this example can still be used to look up the pins.