### PR TITLE
Use file path instead of name

### DIFF
--- a/Examples/Basics/3-SDCardTest/3-SDCardTest.ino
+++ b/Examples/Basics/3-SDCardTest/3-SDCardTest.ino
@@ -56,7 +56,7 @@ void listDir(fs::FS &fs, const char * dirname, uint8_t levels) {
       Serial.print("  DIR : ");
       Serial.println(file.name());
       if (levels) {
-        listDir(fs, file.name(), levels - 1);
+        listDir(fs, file.path(), levels - 1);
       }
     } else {
       Serial.print("  FILE: ");


### PR DESCRIPTION
Otherwise fails:
```
Listing directory: testdir
[  1189][E][vfs_api.cpp:29] open(): testdir does not start with /
```
Fixes #56