### PR TITLE
Fix SPI usage in 2-TouchTest.ino

### DIFF
--- a/Examples/Basics/2-TouchTest/2-TouchTest.ino
+++ b/Examples/Basics/2-TouchTest/2-TouchTest.ino
@@ -53,7 +53,7 @@
 
 // ----------------------------
 
-SPIClass mySpi = SPIClass(HSPI);
+SPIClass mySpi = SPIClass(VSPI);
 XPT2046_Touchscreen ts(XPT2046_CS, XPT2046_IRQ);
 
 TFT_eSPI tft = TFT_eSPI();


### PR DESCRIPTION
Since HSPI is used by the screen, touch has to use VSPI (Fixes #71)