### PR TITLE
Allow examples to be excluded from web flasher

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,19 +18,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Install PlatformIO
@@ -72,9 +72,9 @@ jobs:
 
         echo ']}' >> tmp/examples.json
     - name: Setup Github Page
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v4
     - name: Upload webflash files
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./tmp
 
@@ -90,4 +90,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         pip install --upgrade platformio
     - name: Build
       run: |
-        find . -not -path '*/.*' -type f -name 'platformio.ini' -printf '%h\n' | xargs -i bash -c "(echo {}; pio run -e cyd -e cyd2usb -d {})"
+         find . -not -path '*/.*' -type f -name 'platformio.ini' -print0 | xargs -0 grep -L "; nowebflash" | xargs -i bash -c "(echo {}; pio run -e cyd -e cyd2usb -d {})"
     - name: Merge flash files
       run: |
         find . -path '*/.pio*' -type f -name 'firmware.bin' -printf '%h\n' | xargs -i bash -c "(echo {}; cd {}; ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o merged-flash.bin --flash_mode dio --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin)"

--- a/Examples/Basics/7-HelloRadio/platformio.ini
+++ b/Examples/Basics/7-HelloRadio/platformio.ini
@@ -1,3 +1,4 @@
+; nowebflash
 [platformio]
 src_dir = .
 default_envs = cyd

--- a/Examples/Projects/RollingClock/platformio.ini
+++ b/Examples/Projects/RollingClock/platformio.ini
@@ -1,3 +1,4 @@
+; nowebflash
 [platformio]
 src_dir = .
 default_envs = cyd


### PR DESCRIPTION
Solves #23 
Just add a line
; nowebflash
into platformio.ini file and the example will be excluded from the web flasher