### PR TITLE
Use ILI9342 for CYD2USB rather then ILI9341

### DIFF
--- a/DisplayConfig/CYD2USB/User_Setup.h
+++ b/DisplayConfig/CYD2USB/User_Setup.h
@@ -43,7 +43,7 @@
 
 // Only define one driver, the other ones must be commented out
 // #define ILI9341_DRIVER       // Generic driver for common displays
-#define ILI9341_2_DRIVER // Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
+#define ILI9342_DRIVER
 // #define ST7735_DRIVER      // Define additional parameters below for this display
 // #define ILI9163_DRIVER     // Define additional parameters below for this display
 // #define S6D02A1_DRIVER
@@ -84,11 +84,11 @@
 // #define TFT_WIDTH  80
 // #define TFT_WIDTH  128
 // #define TFT_WIDTH  172 // ST7789 172 x 320
-#define TFT_WIDTH 240 // ST7789 240 x 240 and 240 x 320
+// #define TFT_WIDTH 240 // ST7789 240 x 240 and 240 x 320
 // #define TFT_HEIGHT 160
 // #define TFT_HEIGHT 128
 // #define TFT_HEIGHT 240 // ST7789 240 x 240
-#define TFT_HEIGHT 320 // ST7789 240 x 320
+// #define TFT_HEIGHT 320 // ST7789 240 x 320
 // #define TFT_HEIGHT 240 // GC9A01 240 x 240
 
 // For ST7735 ONLY, define the type of display, originally this was based on the
@@ -112,7 +112,7 @@
 // If colours are inverted (white shows as black) then uncomment one of the next
 // 2 lines try both options, one of the options should correct the inversion.
 
-#define TFT_INVERSION_ON
+// #define TFT_INVERSION_ON
 // #define TFT_INVERSION_OFF
 
 // ##################################################################################

--- a/Examples/Basics/1-HelloWorld/1-HelloWorld.ino
+++ b/Examples/Basics/1-HelloWorld/1-HelloWorld.ino
@@ -34,8 +34,10 @@ TFT_eSPI tft = TFT_eSPI();
 void setup() {
   // Start the tft display and set it to black
   tft.init();
-  //tft.invertDisplay(1); //If you have a CYD2USB - https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display/blob/main/cyd.md#my-cyd-has-two-usb-ports
-  tft.setRotation(1); //This is the display in landscape
+
+#ifdef ILI9341_2_DRIVER
+  tft.setRotation(1); //This is the display in landscape (not for CYD2USB - https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display/blob/main/cyd.md#my-cyd-has-two-usb-ports)
+#endif
   
   // Clear the screen before writing to it
   tft.fillScreen(TFT_BLACK);

--- a/Examples/Basics/1-HelloWorld/platformio.ini
+++ b/Examples/Basics/1-HelloWorld/platformio.ini
@@ -14,10 +14,7 @@ upload_speed = 921600
 board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
 	-DUSE_HSPI_PORT
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
 	-DTFT_SCLK=14
@@ -26,11 +23,10 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
-	-DLOAD_GLCD
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DLOAD_GLCD
 	-DLOAD_FONT2
 	-DLOAD_FONT4
 	-DLOAD_FONT6
@@ -41,10 +37,10 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
+	-DILI9342_DRIVER
 

--- a/Examples/Basics/2-TouchTest/2-TouchTest.ino
+++ b/Examples/Basics/2-TouchTest/2-TouchTest.ino
@@ -68,7 +68,9 @@ void setup() {
 
   // Start the tft display and set it to black
   tft.init();
+#ifdef ILI9341_2_DRIVER
   tft.setRotation(1); //This is the display in landscape
+#endif
 
   // Clear the screen before writing to it
   tft.fillScreen(TFT_BLACK);
@@ -117,6 +119,5 @@ void loop() {
     printTouchToSerial(p);
     printTouchToDisplay(p);
     delay(100);
-
   }
 }

--- a/Examples/Basics/2-TouchTest/platformio.ini
+++ b/Examples/Basics/2-TouchTest/platformio.ini
@@ -15,9 +15,6 @@ upload_speed = 921600
 board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DUSE_HSPI_PORT
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
@@ -27,11 +24,10 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
-	-DLOAD_GLCD
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DLOAD_GLCD
 	-DLOAD_FONT2
 	-DLOAD_FONT4
 	-DLOAD_FONT6
@@ -42,10 +38,10 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
+	-DILI9342_DRIVER
 

--- a/Examples/Basics/4-BacklightControlTest/4-BacklightControlTest.ino
+++ b/Examples/Basics/4-BacklightControlTest/4-BacklightControlTest.ino
@@ -59,7 +59,9 @@ void setup() {
   ledcSetup(LEDC_CHANNEL_0, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
   ledcAttachPin(LCD_BACK_LIGHT_PIN, LEDC_CHANNEL_0);
   
+#ifdef ILI9341_2_DRIVER
   tft.setRotation(1); //This is the display in landscape
+#endif
 
   // Clear the screen before writing to it
   tft.fillScreen(TFT_BLACK);

--- a/Examples/Basics/4-BacklightControlTest/platformio.ini
+++ b/Examples/Basics/4-BacklightControlTest/platformio.ini
@@ -14,9 +14,6 @@ upload_speed = 921600
 board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DUSE_HSPI_PORT
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
@@ -26,11 +23,10 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
-	-DLOAD_GLCD
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DLOAD_GLCD
 	-DLOAD_FONT2
 	-DLOAD_FONT4
 	-DLOAD_FONT6
@@ -41,10 +37,10 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
+	-DILI9342_DRIVER
 

--- a/Examples/Basics/5-LDRTest/5-LDRTest.ino
+++ b/Examples/Basics/5-LDRTest/5-LDRTest.ino
@@ -52,7 +52,9 @@ void setup() {
 
   // Start the tft display and set it to black
   tft.init();
+#ifdef ILI9341_2_DRIVER
   tft.setRotation(1); //This is the display in landscape
+#endif
 
   drawValueToScreen(0); // Just start with a 0 value on screen
 

--- a/Examples/Basics/5-LDRTest/platformio.ini
+++ b/Examples/Basics/5-LDRTest/platformio.ini
@@ -14,9 +14,6 @@ upload_speed = 921600
 board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DUSE_HSPI_PORT
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
@@ -26,11 +23,10 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
-	-DLOAD_GLCD
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DLOAD_GLCD
 	-DLOAD_FONT2
 	-DLOAD_FONT4
 	-DLOAD_FONT6
@@ -41,10 +37,10 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
+	-DILI9342_DRIVER
 

--- a/Examples/Basics/7-HelloRadio/7-HelloRadio.ino
+++ b/Examples/Basics/7-HelloRadio/7-HelloRadio.ino
@@ -65,7 +65,9 @@ void setup()
   
   // Start the TFT display and set it to black
   tft.init();
+#ifdef ILI9341_2_DRIVER
   tft.setRotation(1); //This is the display in landscape
+#endif
   tft.setTextWrap(true, true);
 
   // Clear the screen before writing to it and set default text colors

--- a/Examples/Basics/7-HelloRadio/platformio.ini
+++ b/Examples/Basics/7-HelloRadio/platformio.ini
@@ -16,9 +16,6 @@ upload_speed = 921600
 board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DUSE_HSPI_PORT
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
@@ -28,11 +25,10 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
-	-DLOAD_GLCD
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
+	-DLOAD_GLCD
 	-DLOAD_FONT2
 	-DLOAD_FONT4
 	-DLOAD_FONT6
@@ -43,10 +39,9 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
-
+	-DILI9342_DRIVER

--- a/Examples/Showcases/1-Slideshow/1-Slideshow.ino
+++ b/Examples/Showcases/1-Slideshow/1-Slideshow.ino
@@ -177,7 +177,9 @@ void setup() {
 
   // Start the tft display and set it to black
   tft.init();
+#ifdef ILI9341_2_DRIVER
   tft.setRotation(1); //This is the display in landscape
+#endif
   
   // Clear the screen before writing to it
   tft.fillScreen(TFT_BLACK);
@@ -186,7 +188,7 @@ void setup() {
   tft.setSwapBytes(true);
 
   // Fix image quality for CYD2USB
-#ifdef TFT_INVERSION_ON
+#ifndef ILI9342_DRIVER
   tft.writecommand(ILI9341_GAMMASET); //Gamma curve selected
   tft.writedata(2);
   delay(120);

--- a/Examples/Showcases/1-Slideshow/platformio.ini
+++ b/Examples/Showcases/1-Slideshow/platformio.ini
@@ -7,7 +7,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps = 
-	bodmer/TFT_eSPI@^2.5.33
+	bodmer/TFT_eSPI@^2.5.34
 	bitbank2/JPEGDEC@^1.2.8
 	greiman/SdFat@^2.2.2
 	nitek/XPT2046_Bitbang_Slim@^2.0.0
@@ -18,9 +18,6 @@ board_build.partitions=min_spiffs.csv
 board_build.arduino.upstream_packages = no
 build_flags =
 	-DUSER_SETUP_LOADED
-	-DILI9341_2_DRIVER
-	-DTFT_WIDTH=240
-	-DTFT_HEIGHT=320
 	-DTFT_MISO=12
 	-DTFT_MOSI=13
 	-DTFT_SCLK=14
@@ -30,7 +27,6 @@ build_flags =
 	-DTFT_RST=-1
 	-DTFT_BL=21
 	-DTFT_BACKLIGHT_ON=HIGH
-	-DTFT_BACKLIGHT_OFF=LOW
 	-DSPI_FREQUENCY=55000000
 	-DSPI_READ_FREQUENCY=20000000
 	-DSPI_TOUCH_FREQUENCY=2500000
@@ -46,10 +42,9 @@ build_flags =
 [env:cyd]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_OFF
+	-DILI9341_2_DRIVER
 
 [env:cyd2usb]
 build_flags =
 	${env.build_flags}
-	-DTFT_INVERSION_ON
-
+	-DILI9342_DRIVER


### PR DESCRIPTION
CYD2USB seems to feature a ILI9342 rather then a ILI9341. While the later one still works for some strange reason, it probably makes sense to use the correct display for educational use.