### PR TITLE
Fix build with Esphome 2024.4.1 - use the new calibration property

### DIFF
--- a/Examples/ESPHome/4-TouchDemo/yellowtft1.yaml
+++ b/Examples/ESPHome/4-TouchDemo/yellowtft1.yaml
@@ -155,9 +155,10 @@ touchscreen:
   interrupt_pin: GPIO36
   update_interval: 50ms
   threshold: 400
-  calibration_x_min: 3860
-  calibration_x_max: 280
-  calibration_y_min: 340
-  calibration_y_max: 3860
+  calibration:
+    x_min: 3860
+    x_max: 280
+    y_min: 340
+    y_max: 3860
   transform:
     swap_xy: false      


### PR DESCRIPTION
See https://esphome.io/components/touchscreen/xpt2046.html