### PR TITLE
Updated touchscreen calibration

### DIFF
--- a/Examples/ESPHome/7-ExtendedTouchDemo/yellowtft1.yaml
+++ b/Examples/ESPHome/7-ExtendedTouchDemo/yellowtft1.yaml
@@ -240,10 +240,11 @@ touchscreen:
   interrupt_pin: GPIO36
   update_interval: 50ms
   threshold: 400
-  calibration_x_min: 3860
-  calibration_x_max: 280
-  calibration_y_min: 340
-  calibration_y_max: 3860
+  calibration:
+    x_min: 3860
+    x_max: 280
+    y_min: 340
+    y_max: 3860
   transform:
     swap_xy: false
 # When the display is touched, turn on the backlight,


### PR DESCRIPTION
Changed syntax for touchscreen calibration to work in ESPHome 2024.4.2 https://esphome.io/components/touchscreen/xpt2046.html?highlight=xpt2046