### PR TITLE
Touchscreen calibration and coordinates updated

### DIFF
--- a/Examples/ESPHome/7-ExtendedTouchDemo/yellowtft1.yaml
+++ b/Examples/ESPHome/7-ExtendedTouchDemo/yellowtft1.yaml
@@ -223,7 +223,11 @@ display:
     spi_id: tft
     cs_pin: GPIO15
     dc_pin: GPIO2
-    rotation: 90
+    transform:
+      swap_xy: true
+    dimensions:
+      width: 320
+      height: 240
     lambda: |-
       it.fill(id(Color::BLACK));
       it.filled_circle(80, 120, 60, id(ha_blue));
@@ -240,12 +244,13 @@ touchscreen:
   interrupt_pin: GPIO36
   update_interval: 50ms
   threshold: 400
-  calibration_x_min: 3860
-  calibration_x_max: 280
-  calibration_y_min: 340
-  calibration_y_max: 3860
+  calibration:
+    x_min: 180
+    x_max: 3800
+    y_min: 240
+    y_max: 3860
   transform:
-    swap_xy: false
+    swap_xy: true
 # When the display is touched, turn on the backlight,
 # store that we had a recent touch, and update the UI
   on_touch:


### PR DESCRIPTION
- Updated calibration to [new syntax](https://esphome.io/components/touchscreen/xpt2046.html?highlight=xpt2046#)
- Fixed touch coordinates to match pixels
- Changed software rotation to hardware rotation

Since the touchscreen is not very precise, I recommend calibrating it as described on [esphome.io](https://esphome.io/components/touchscreen/#calibration) and changing the values accordingly.
