### PR TITLE
Add Tetris for ESP32 with Nintendo 64 controller support project

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -27,6 +27,7 @@ Projects appearing on here is not necessarily a seal of approval from me, I will
 |GitHub-Stats| This Arduino project fetches and displays GitHub repository statistics such as star count, open issues, forks and notifactions on a CYD or via serial communication. Ideal for developers to monitor project metrics in real time.| [ATOMNFT](https://github.com/ATOMNFT) | | [Github](https://github.com/ATOMNFT/ESP32-CYD-Projects/tree/main/GitHub-Stats) | |
 | Midbar-Firebase-Edition | An advanced password vault that stores the encrypted data in the cloud while keeping the cryptographic keys on the edge! | [Northstrix](https://github.com/Northstrix) | PS/2 keyboard and an optional STM32F103C8T6 (if you want it to emulate the USB keyboard)  | [Github](https://github.com/Northstrix/Midbar-Firebase-Edition)
 | Electronic-Shelf-Label-Management-System | A simple device for displaying relevant product information. It gets the encrypted images via UDP. | [Northstrix](https://github.com/Northstrix)|                                                           | [Github](https://github.com/Northstrix/Electronic-Shelf-Label-Management-System)
+| ESP32-Tetris-With-Nintendo-64-Controller | Tetris for ESP32 with Nintendo 64 controller support                      | [Northstrix](https://github.com/Northstrix) | Nintendo 64 Controller and Arduino Nano                                           | [Github](https://github.com/Northstrix/ESP32-Tetris-With-Nintendo-64-Controller)
 
 (\#) = Project not added by original author
 


### PR DESCRIPTION
Added a Tetris for ESP32 with Nintendo 64 controller support. 

Based on the work of [Brian Lough](https://github.com/witnessmenow)
Original project: https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display/tree/main/Examples/Projects/TetrisWithNunchuck

Tutorial is available at https://www.instructables.com/How-to-Play-Tetris-on-ESP32-CYD-With-Nintendo-64-C/