### PR TITLE
Issue with including to PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,9 +19,9 @@
   "url": "https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display",
   "architectures": ["esp32"],
   "frameworks": "Arduino",
-  "dependencies": {
+  "dependencies": [
     "bodmer/TFT_eSPI@^2.5.31"
-  },
+  ],
   "examples": [
     {
       "name": "1.Hello World",


### PR DESCRIPTION
I was having issues with importing this to PlatformIO to start learning how to program my CYD. It looks like the "dependencies" was written as a K/V pair instead of a list which was breaking PlatformIO imports. 