### PR TITLE
SD card formatting tool

### DIFF
--- a/Tools/README.md
+++ b/Tools/README.md
@@ -1,0 +1,3 @@
+# CYD Tools
+
+Here are some tools to help with CYD projects.

--- a/Tools/SDFmt/README.md
+++ b/Tools/SDFmt/README.md
@@ -1,0 +1,38 @@
+# SDFmt
+
+## Overview
+
+The SDFmt tool is a utility for formatting SD cards using the SD card library
+provided by the ESP32 Arduino framework.
+
+If you have an SD card that you cannot get the CYD to utilize, this tool
+may be able to help.
+
+> ***Caveat:*** If you are using this tool because you cannot get the CYD to
+> utilize the card when formatted by other platforms, then you may be presented
+> with the inverse scenario when the formatting is complete (i.e., the platform
+> you were originally attempting to format the card with may no longer be able
+> to utilize the CYD formatted card). This is a useful solution if you goal is
+> to use the card only with the CYD. You can always restore the card to its
+> original (CYD incompatible) state by reformatting it with the original
+> platform.
+
+## Setup
+
+Upload the SDFmt project to your CYD board.
+
+## Usage
+
+> ***NOTICE:*** Technically the SD card must be empty before formatting because
+> this tool uses the `format_if_empty` flag of the `SDFS::begin` method.
+> However, in practice, if your card fails to mount then it will be formatted
+> regardless of its contents.
+
+1. Insert the SD card you want to format into the CYD.
+2. Press the reset button on the CYD to format the card.
+    * Progress is indicated by the board LED:
+        * Blue: In progress.
+        * Green: Success.
+        * Red: Error.
+    * Progress messages are also written to the serial console.
+3. Repeat steps 1 and 2 for each card you want to format.

--- a/Tools/SDFmt/SDFmt.ino
+++ b/Tools/SDFmt/SDFmt.ino
@@ -1,0 +1,131 @@
+/*******************************************************************
+    SD card formatting tool for the CYD.
+
+    This tool will format the inserted SD card using the SD card
+    library provided by the ESP32 Arduino framework.
+
+    Based on the Examples/3-SDCardTest and Examples/6-LEDTest
+    projects in this repository.
+
+    https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display
+
+    Written by Ian Dinwoodie
+    GitHub: https://www.github.com/iandinwoodie
+ *******************************************************************/
+
+// ----------------------------
+// Standard Libraries
+// ----------------------------
+
+#include "FS.h"
+#include "SD.h"
+#include "SPI.h"
+
+// ----------------------------
+// SD Reader pins (default VSPI pins)
+// ----------------------------
+//#define SD_SCK 18
+//#define SD_MISO 19
+//#define SD_MOSI 23
+//#define SD_CS 5
+
+// ----------------------------
+// LED Pins
+// ----------------------------
+#define CYD_LED_BLUE 17
+#define CYD_LED_RED 4
+#define CYD_LED_GREEN 16
+
+// ----------------------------
+
+enum Status {
+  READY,
+  RUNNING,
+  ERROR,
+  SUCCESS
+};
+
+SPIClass* spi = nullptr;
+
+Status formatSD() {
+  Serial.println("Formatting SD card ...");
+
+  bool format_if_empty = true; // This is how we format the SD card.
+  if (!SD.begin(SS, *spi, 80000000, "/sd", 5U, format_if_empty)) {
+    Serial.println("Error: Failed to format card.");
+    return ERROR;
+  } else {
+    Serial.println("Success: Card formatted.");
+  }
+  uint8_t cardType = SD.cardType();
+
+  if (cardType == CARD_NONE) {
+    Serial.println("Error: No SD card attached.");
+    return ERROR;
+  }
+
+  Serial.print("SD card type: ");
+  if (cardType == CARD_MMC) {
+    Serial.println("MMC");
+  } else if (cardType == CARD_SD) {
+    Serial.println("SDSC");
+  } else if (cardType == CARD_SDHC) {
+    Serial.println("SDHC");
+  } else {
+    Serial.println("UNKNOWN");
+  }
+
+  uint64_t cardSize = SD.cardSize() / (1024 * 1024);
+  Serial.printf("SD card size: %lluMB\n", cardSize);
+  Serial.printf("Total space: %lluMB\n", SD.totalBytes() / (1024 * 1024));
+  Serial.printf("Used space: %lluMB\n", SD.usedBytes() / (1024 * 1024));
+
+  return SUCCESS;
+}
+
+void updateLED(Status status) {
+  switch (status) {
+    case RUNNING: // Set LED to blue.
+      digitalWrite(CYD_LED_RED, HIGH);
+      digitalWrite(CYD_LED_GREEN, HIGH);
+      digitalWrite(CYD_LED_BLUE, LOW);
+      break;
+    case ERROR: // Set LED to red.
+      digitalWrite(CYD_LED_RED, LOW);
+      digitalWrite(CYD_LED_GREEN, HIGH);
+      digitalWrite(CYD_LED_BLUE, HIGH);
+      break;
+    case SUCCESS: // Set LED to green.
+      digitalWrite(CYD_LED_RED, LOW);
+      digitalWrite(CYD_LED_GREEN, LOW);
+      digitalWrite(CYD_LED_BLUE, HIGH);
+      break;
+    default: // Set LED off.
+      digitalWrite(CYD_LED_RED, HIGH);
+      digitalWrite(CYD_LED_GREEN, HIGH);
+      digitalWrite(CYD_LED_BLUE, HIGH);
+      break;
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  spi = new SPIClass(VSPI);
+
+  pinMode(CYD_LED_RED, OUTPUT);
+  pinMode(CYD_LED_GREEN, OUTPUT);
+  pinMode(CYD_LED_BLUE, OUTPUT);
+
+  updateLED(READY);
+}
+
+void loop() {
+  static bool complete = false;
+  if (!complete) {
+    updateLED(RUNNING);
+    Status status = formatSD();
+    updateLED(status);
+    complete = true;
+  }
+}
+

--- a/Tools/SDFmt/platformio.ini
+++ b/Tools/SDFmt/platformio.ini
@@ -1,0 +1,23 @@
+[platformio]
+src_dir = .
+default_envs = cyd
+
+[env]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps = 
+	SD
+	FS
+	SPI
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+upload_speed = 921600
+board_build.partitions=min_spiffs.csv
+
+[env:cyd]
+# no difference
+
+[env:cyd2usb]
+# no difference
+


### PR DESCRIPTION
## Overview

This patch adds an SD card formatting tool (`SDFmt`) that formats the currently inserted SD card using the ESP32 Arduino framework's SD card library.

## Rationale

I had recently ordered some 256MB SD cards (Class 4)  to use with the CYD. The CYD was unable to utilize the SD card and produced the following error:

```txt
[    46][E][sd_diskio.cpp:806] sdcard_mount(): f_mount failed: (13) There is no valid FAT volume
```

I attempted to remedy the situation by formatting the card with the following tools:

* Windows Disk Management
* macOS Disk Utility
* SD Association SD Card Formatter

Regardless, the card continued to fail to mount with the `no valid FAT volume` error message. However, I was able to remedy the situation using the `format_if_empty` flag of the `SDFS::begin` method. The caveat of this solution is that the resulting formatted card can be utilized by the CYD, but none of the other platforms recognize it as a valid format.

I think this is a worthwhile addition to the CYD collection for users seeking out smaller capacity SD cards that may run into the same scenario.