### PR TITLE
docs: add FUNDING.yml to enable GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: witnessmenow


### PR DESCRIPTION
Hi @witnessmenow !

I noticed you have GitHub Sponsors enabled but no FUNDING.yml file. This PR adds the file to help bring more visibility to your sponsorship options.

This small addition will:
- Display a sponsor button on your repository
- Show sponsorship options in the sidebar
- Help supporters find ways to fund your work

Thank you for creating this project!