### PR TITLE
Set prevDay to current day to avoid redrawing the full date every iteration

### DIFF
--- a/Examples/Projects/RollingClock/RollingClock.ino
+++ b/Examples/Projects/RollingClock/RollingClock.ino
@@ -350,6 +350,7 @@ void DrawDate(time_t utc)
     tft.setTextSize(4);
     tft.fillRect(0, 170 - h, 320, h, TFT_BLACK);
     tft.drawString(dayNames[dow], 320 / 2, 170);
+    prevDay = dd;
   }
 }
 


### PR DESCRIPTION
The function `void DrawDate(time_t utc)` from the RollingClock project was not updating the variable `prevDay`, causing the display date to be updated in every iteration:

```C
void DrawDate(time_t utc)
{
  time_t local = myTZ.toLocal(utc, &tcr);
  int dd = day(local);
  int mth = month(local);
  int yr = year(local);

  if (dd != prevDay) // <----------
  {
  //   ...
```

This pull request saves the current day (dd) in `prevDay` whenever the display is updated to show current day.