### PR TITLE
Backlight for 2.4 inch (Chipset ESP32-D0WD-V3)

### DIFF
--- a/PINS.md
+++ b/PINS.md
@@ -123,7 +123,7 @@ Uses the HSPI
 |IO15|TFT_CS||
 |IO21|TFT_BL|Also on P3 connector, for some reason|
 
-// For the 2.4 inch display (Chipset is ESP32-D0WD-V3), the Backlight (BL) Pin is the IO27 (define it 27 in your code). 
+// For the 2.4 inch display (Chipset is ESP32-D0WD-V3), the Backlight (BL) Pin is the IO21 (define it 21 in your code). 
 
 ## Test points
 |Pad|Use|Note|


### PR DESCRIPTION
SPI pins are the one mentioned in the Pins section.

Backlight was enabled with pin 27 on.