### PR TITLE
Fix typo in Micropython.md

### DIFF
--- a/Examples/Micropython/Micropython.md
+++ b/Examples/Micropython/Micropython.md
@@ -22,7 +22,7 @@ Not yet tested:
 
 * ❓ I2S audio output (should be [natively supported in Micropython](https://docs.micropython.org/en/latest/library/machine.I2S.html))
 
-## Addidtional Micropython Examples for LVGL8
+## Additional Micropython Examples for LVGL8
 Aditional examples demonstrating the use of LVGL8 on the CYD can be found [here](https://github.com/de-dh/CYD2-MPY-LVGL).
 The repositry also includes a link to precompiled firmware images of Micropython + LVGL for CYD.
 Differences in the display driver's configuration for the one-usb-port version and the two-port-version are explained.


### PR DESCRIPTION
Corrected spelling errors in the Micropython documentation.