### PR TITLE
Add examples for the LovyanGFX library and the Adafruit library using hardware SPI

### DIFF
--- a/Examples/AlternativeLibraries/Adafruit_ILI9341/2-Adafruit_ILI9341_HWSPI/2-Adafruit_ILI9341_HWSPI.ino
+++ b/Examples/AlternativeLibraries/Adafruit_ILI9341/2-Adafruit_ILI9341_HWSPI/2-Adafruit_ILI9341_HWSPI.ino
@@ -1,0 +1,352 @@
+// ---------------------------------------------------------------------
+// 2-Adafruit_ILI9341_HWSPI
+// ========================
+// This is the TFT_eSPI graphics benchmark adapted to use ArduinoGFX
+// with hardware SPI. The original Arduino code uses software SPI and
+// that is very slow compared to TFT_eSPI.
+// ---------------------------------------------------------------------
+#include <SPI.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_ILI9341.h>
+
+// For the Arduino we need to define the colours
+#define TFT_BLACK ILI9341_BLACK
+#define TFT_WHITE ILI9341_WHITE
+#define TFT_RED ILI9341_RED
+#define TFT_GREEN ILI9341_GREEN
+#define TFT_BLUE ILI9341_BLUE
+#define TFT_CYAN ILI9341_CYAN
+#define TFT_YELLOW ILI9341_YELLOW
+#define TFT_MAGENTA ILI9341_MAGENTA
+
+// The original Arduino code uses:
+// Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST, TFT_MISO);
+// but this configures the library to use software SPI and that is very
+// slow. The code below uses hardware SPI instead, which is much faster.
+#define TFT_CS   15 
+#define TFT_DC    2
+#define TFT_RST  -1
+SPIClass tftSPI = SPIClass(HSPI);
+Adafruit_ILI9341 tft = Adafruit_ILI9341(&tftSPI, TFT_DC, TFT_CS, TFT_RST);
+
+// Global variables use for timing
+unsigned long total = 0;
+unsigned long tn = 0;
+
+// ---------------------------------------------------------------------
+// setup
+// -----
+// ---------------------------------------------------------------------
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+  Serial.println("Starting test of the ArduinoGFX graphics library");
+
+  // Start the tft display and set it to black
+  tft.begin();
+  // For the Arduino we need to turn the screen on manually
+  pinMode(21, OUTPUT);
+  digitalWrite(21, HIGH);
+
+  // This is the display in landscape with the USB port on the left
+  tft.setRotation(0);
+
+  // Start the test
+  tn = micros();
+  tft.fillScreen(TFT_BLACK);
+
+  yield(); Serial.println(F("Benchmark                Time (microseconds)"));
+
+  yield(); Serial.print(F("Screen fill              "));
+  yield(); Serial.println(testFillScreen());
+
+  yield(); Serial.print(F("Text                     "));
+  yield(); Serial.println(testText());
+
+  yield(); Serial.print(F("Lines                    "));
+  yield(); Serial.println(testLines(TFT_CYAN));
+
+  yield(); Serial.print(F("Horiz/Vert Lines         "));
+  yield(); Serial.println(testFastLines(TFT_RED, TFT_BLUE));
+
+  yield(); Serial.print(F("Rectangles (outline)     "));
+  yield(); Serial.println(testRects(TFT_GREEN));
+
+  yield(); Serial.print(F("Rectangles (filled)      "));
+  yield(); Serial.println(testFilledRects(TFT_YELLOW, TFT_MAGENTA));
+
+  yield(); Serial.print(F("Circles (outline)        "));
+  yield(); Serial.println(testCircles(10, TFT_WHITE));
+
+  yield(); Serial.print(F("Circles (filled)         "));
+  yield(); Serial.println(testFilledCircles(10, TFT_MAGENTA));
+
+  yield(); Serial.print(F("Triangles (outline)      "));
+  yield(); Serial.println(testTriangles());
+
+  yield(); Serial.print(F("Triangles (filled)       "));
+  yield(); Serial.println(testFilledTriangles());
+
+  yield(); Serial.print(F("Rounded rects (outline)  "));
+  yield(); Serial.println(testRoundRects());
+
+  yield(); Serial.print(F("Rounded rects (filled)   "));
+  yield(); Serial.println(testFilledRoundRects());
+
+  yield(); Serial.println(F("Done!")); yield();
+}
+
+// ---------------------------------------------------------------------
+// loop
+// -----
+// ---------------------------------------------------------------------
+void loop(void) {
+  for (uint8_t rotation = 0; rotation < 4; rotation++) {
+    tft.setRotation(rotation);
+    testText();
+    delay(2000);
+  }
+}
+
+
+unsigned long testFillScreen() {
+  unsigned long start = micros();
+  tft.fillScreen(TFT_BLACK);
+  tft.fillScreen(TFT_RED);
+  tft.fillScreen(TFT_GREEN);
+  tft.fillScreen(TFT_BLUE);
+  tft.fillScreen(TFT_BLACK);
+  return micros() - start;
+}
+
+unsigned long testText() {
+  tft.fillScreen(TFT_BLACK);
+  unsigned long start = micros();
+  tft.setCursor(0, 0);
+  tft.setTextColor(TFT_WHITE);  tft.setTextSize(1);
+  tft.println("Hello World!");
+  tft.setTextColor(TFT_YELLOW); tft.setTextSize(2);
+  tft.println(1234.56);
+  tft.setTextColor(TFT_RED);    tft.setTextSize(3);
+  tft.println(0xDEADBEEF, HEX);
+  tft.println();
+  tft.setTextColor(TFT_GREEN);
+  tft.setTextSize(5);
+  tft.println("Groop");
+  tft.setTextSize(2);
+  tft.println("I implore thee,");
+  //tft.setTextColor(TFT_GREEN,TFT_BLACK);
+  tft.setTextSize(1);
+  tft.println("my foonting turlingdromes.");
+  tft.println("And hooptiously drangle me");
+  tft.println("with crinkly bindlewurdles,");
+  tft.println("Or I will rend thee");
+  tft.println("in the gobberwarts");
+  tft.println("with my blurglecruncheon,");
+  tft.println("see if I don't!");
+  return micros() - start;
+}
+
+unsigned long testLines(uint16_t color) {
+  unsigned long start, t;
+  int           x1, y1, x2, y2,
+                w = tft.width(),
+                h = tft.height();
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1 = y1 = 0;
+  y2    = h - 1;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = w - 1;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t     = micros() - start; // fillScreen doesn't count against timing
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = w - 1;
+  y1    = 0;
+  y2    = h - 1;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = 0;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t    += micros() - start;
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = 0;
+  y1    = h - 1;
+  y2    = 0;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = w - 1;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t    += micros() - start;
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = w - 1;
+  y1    = h - 1;
+  y2    = 0;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = 0;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+
+  return micros() - start;
+}
+
+unsigned long testFastLines(uint16_t color1, uint16_t color2) {
+  unsigned long start;
+  int           x, y, w = tft.width(), h = tft.height();
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (y = 0; y < h; y += 5) tft.drawFastHLine(0, y, w, color1);
+  for (x = 0; x < w; x += 5) tft.drawFastVLine(x, 0, h, color2);
+
+  return micros() - start;
+}
+
+unsigned long testRects(uint16_t color) {
+  unsigned long start;
+  int           n, i, i2,
+                cx = tft.width()  / 2,
+                cy = tft.height() / 2;
+
+  tft.fillScreen(TFT_BLACK);
+  n     = min(tft.width(), tft.height());
+  start = micros();
+  for (i = 2; i < n; i += 6) {
+    i2 = i / 2;
+    tft.drawRect(cx - i2, cy - i2, i, i, color);
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledRects(uint16_t color1, uint16_t color2) {
+  unsigned long start, t = 0;
+  int           n, i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  n = min(tft.width(), tft.height());
+  for (i = n - 1; i > 0; i -= 6) {
+    i2    = i / 2;
+    start = micros();
+    tft.fillRect(cx - i2, cy - i2, i, i, color1);
+    t    += micros() - start;
+    // Outlines are not included in timing results
+    tft.drawRect(cx - i2, cy - i2, i, i, color2);
+  }
+
+  return t;
+}
+
+unsigned long testFilledCircles(uint8_t radius, uint16_t color) {
+  unsigned long start;
+  int x, y, w = tft.width(), h = tft.height(), r2 = radius * 2;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (x = radius; x < w; x += r2) {
+    for (y = radius; y < h; y += r2) {
+      tft.fillCircle(x, y, radius, color);
+    }
+  }
+
+  return micros() - start;
+}
+
+unsigned long testCircles(uint8_t radius, uint16_t color) {
+  unsigned long start;
+  int           x, y, r2 = radius * 2,
+                      w = tft.width()  + radius,
+                      h = tft.height() + radius;
+
+  // Screen is not cleared for this one -- this is
+  // intentional and does not affect the reported time.
+  start = micros();
+  for (x = 0; x < w; x += r2) {
+    for (y = 0; y < h; y += r2) {
+      tft.drawCircle(x, y, radius, color);
+    }
+  }
+
+  return micros() - start;
+}
+
+unsigned long testTriangles() {
+  unsigned long start;
+  int           n, i, cx = tft.width()  / 2 - 1,
+                      cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  n     = min(cx, cy);
+  start = micros();
+  for (i = 0; i < n; i += 5) {
+    tft.drawTriangle(
+      cx    , cy - i, // peak
+      cx - i, cy + i, // bottom left
+      cx + i, cy + i, // bottom right
+      tft.color565(0, 0, i));
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledTriangles() {
+  unsigned long start, t = 0;
+  int           i, cx = tft.width()  / 2 - 1,
+                   cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (i = min(cx, cy); i > 10; i -= 5) {
+    start = micros();
+    tft.fillTriangle(cx, cy - i, cx - i, cy + i, cx + i, cy + i,
+                     tft.color565(0, i, i));
+    t += micros() - start;
+    tft.drawTriangle(cx, cy - i, cx - i, cy + i, cx + i, cy + i,
+                     tft.color565(i, i, 0));
+  }
+
+  return t;
+}
+
+unsigned long testRoundRects() {
+  unsigned long start;
+  int           w, i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  w     = min(tft.width(), tft.height());
+  start = micros();
+  for (i = 0; i < w; i += 6) {
+    i2 = i / 2;
+    tft.drawRoundRect(cx - i2, cy - i2, i, i, i / 8, tft.color565(i, 0, 0));
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledRoundRects() {
+  unsigned long start;
+  int           i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (i = min(tft.width(), tft.height()); i > 20; i -= 6) {
+    i2 = i / 2;
+    tft.fillRoundRect(cx - i2, cy - i2, i, i, i / 8, tft.color565(0, i, 0));
+  }
+
+  return micros() - start;
+}

--- a/Examples/AlternativeLibraries/Adafruit_ILI9341/2-Adafruit_ILI9341_HWSPI/README.md
+++ b/Examples/AlternativeLibraries/Adafruit_ILI9341/2-Adafruit_ILI9341_HWSPI/README.md
@@ -1,0 +1,5 @@
+# 2-Adafruit_ILI9341_HWSPI
+
+This is adapted from the speed test sketch provided as an example in the TFT_eSPI library, which was itself adapted from the Adafruit speed test sketch.
+
+The original Adafruit test code uses software SPI and that is very slow. This code shows how to use hardware SPI instead. Using hardware SPI the Arduino library is about 50% slower than TFT_eSPI, although for some reason drawing lines that are not horizontal or vertical is about a factor of 4 slower.

--- a/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/1-LovyanGFX.ino
+++ b/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/1-LovyanGFX.ino
@@ -1,0 +1,332 @@
+// ---------------------------------------------------------------------
+// 3-LovyanGFX
+// ===========
+// This is the TFT_eSPI graphics benchmark adapted to use the LovyanGFX
+// library.
+// ---------------------------------------------------------------------
+
+#include <LovyanGFX.hpp>
+#include "LovyanGFX_CYD_Settings.h"
+
+LGFX tft;
+
+// Global variables use for timing
+unsigned long total = 0;
+unsigned long tn = 0;
+
+// ---------------------------------------------------------------------
+// setup
+// -----
+// ---------------------------------------------------------------------
+void setup() {
+  Serial.begin(115200);
+  delay(2000);
+  Serial.println("Starting test of the LovyanGFX graphics library");
+
+  // Start the tft display and set it to black
+  tft.init();
+
+  // This is the display in landscape with the USB port on the left.
+  // On the CYD rotations 0 to 3 are mirrored so use 4 to 7.
+  tft.setRotation(6);
+
+  // Start the test
+  tn = micros();
+  tft.fillScreen(TFT_BLACK);
+
+  yield(); Serial.println(F("Benchmark                Time (microseconds)"));
+
+  yield(); Serial.print(F("Screen fill              "));
+  yield(); Serial.println(testFillScreen());
+
+  yield(); Serial.print(F("Text                     "));
+  yield(); Serial.println(testText());
+
+  yield(); Serial.print(F("Lines                    "));
+  yield(); Serial.println(testLines(TFT_CYAN));
+
+  yield(); Serial.print(F("Horiz/Vert Lines         "));
+  yield(); Serial.println(testFastLines(TFT_RED, TFT_BLUE));
+
+  yield(); Serial.print(F("Rectangles (outline)     "));
+  yield(); Serial.println(testRects(TFT_GREEN));
+
+  yield(); Serial.print(F("Rectangles (filled)      "));
+  yield(); Serial.println(testFilledRects(TFT_YELLOW, TFT_MAGENTA));
+
+  yield(); Serial.print(F("Circles (outline)        "));
+  yield(); Serial.println(testCircles(10, TFT_WHITE));
+
+  yield(); Serial.print(F("Circles (filled)         "));
+  yield(); Serial.println(testFilledCircles(10, TFT_MAGENTA));
+
+  yield(); Serial.print(F("Triangles (outline)      "));
+  yield(); Serial.println(testTriangles());
+
+  yield(); Serial.print(F("Triangles (filled)       "));
+  yield(); Serial.println(testFilledTriangles());
+
+  yield(); Serial.print(F("Rounded rects (outline)  "));
+  yield(); Serial.println(testRoundRects());
+
+  yield(); Serial.print(F("Rounded rects (filled)   "));
+  yield(); Serial.println(testFilledRoundRects());
+
+  yield(); Serial.println(F("Done!")); yield();
+}
+
+// ---------------------------------------------------------------------
+// loop
+// -----
+// ---------------------------------------------------------------------
+void loop(void) {
+  // With LovyanGFX rotations 0 to 3 are mirrored. Use 4 to 7 instead.
+  for (uint8_t rotation = 4; rotation < 7; rotation++) {
+    tft.setRotation(rotation);
+    testText();
+    delay(2000);
+  }
+}
+
+
+unsigned long testFillScreen() {
+  unsigned long start = micros();
+  tft.fillScreen(TFT_BLACK);
+  tft.fillScreen(TFT_RED);
+  tft.fillScreen(TFT_GREEN);
+  tft.fillScreen(TFT_BLUE);
+  tft.fillScreen(TFT_BLACK);
+  return micros() - start;
+}
+
+unsigned long testText() {
+  tft.fillScreen(TFT_BLACK);
+  unsigned long start = micros();
+  tft.setCursor(0, 0);
+  tft.setTextColor(TFT_WHITE);  tft.setTextSize(1);
+  tft.println("Hello World!");
+  tft.setTextColor(TFT_YELLOW); tft.setTextSize(2);
+  tft.println(1234.56);
+  tft.setTextColor(TFT_RED);    tft.setTextSize(3);
+  tft.println(0xDEADBEEF, HEX);
+  tft.println();
+  tft.setTextColor(TFT_GREEN);
+  tft.setTextSize(5);
+  tft.println("Groop");
+  tft.setTextSize(2);
+  tft.println("I implore thee,");
+  //tft.setTextColor(TFT_GREEN,TFT_BLACK);
+  tft.setTextSize(1);
+  tft.println("my foonting turlingdromes.");
+  tft.println("And hooptiously drangle me");
+  tft.println("with crinkly bindlewurdles,");
+  tft.println("Or I will rend thee");
+  tft.println("in the gobberwarts");
+  tft.println("with my blurglecruncheon,");
+  tft.println("see if I don't!");
+  return micros() - start;
+}
+
+unsigned long testLines(uint16_t color) {
+  unsigned long start, t;
+  int           x1, y1, x2, y2,
+                w = tft.width(),
+                h = tft.height();
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1 = y1 = 0;
+  y2    = h - 1;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = w - 1;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t     = micros() - start; // fillScreen doesn't count against timing
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = w - 1;
+  y1    = 0;
+  y2    = h - 1;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = 0;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t    += micros() - start;
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = 0;
+  y1    = h - 1;
+  y2    = 0;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = w - 1;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  t    += micros() - start;
+
+  tft.fillScreen(TFT_BLACK);
+
+  x1    = w - 1;
+  y1    = h - 1;
+  y2    = 0;
+  start = micros();
+  for (x2 = 0; x2 < w; x2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+  x2    = 0;
+  for (y2 = 0; y2 < h; y2 += 6) tft.drawLine(x1, y1, x2, y2, color);
+
+  return micros() - start;
+}
+
+unsigned long testFastLines(uint16_t color1, uint16_t color2) {
+  unsigned long start;
+  int           x, y, w = tft.width(), h = tft.height();
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (y = 0; y < h; y += 5) tft.drawFastHLine(0, y, w, color1);
+  for (x = 0; x < w; x += 5) tft.drawFastVLine(x, 0, h, color2);
+
+  return micros() - start;
+}
+
+unsigned long testRects(uint16_t color) {
+  unsigned long start;
+  int           n, i, i2,
+                cx = tft.width()  / 2,
+                cy = tft.height() / 2;
+
+  tft.fillScreen(TFT_BLACK);
+  n     = min(tft.width(), tft.height());
+  start = micros();
+  for (i = 2; i < n; i += 6) {
+    i2 = i / 2;
+    tft.drawRect(cx - i2, cy - i2, i, i, color);
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledRects(uint16_t color1, uint16_t color2) {
+  unsigned long start, t = 0;
+  int           n, i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  n = min(tft.width(), tft.height());
+  for (i = n - 1; i > 0; i -= 6) {
+    i2    = i / 2;
+    start = micros();
+    tft.fillRect(cx - i2, cy - i2, i, i, color1);
+    t    += micros() - start;
+    // Outlines are not included in timing results
+    tft.drawRect(cx - i2, cy - i2, i, i, color2);
+  }
+
+  return t;
+}
+
+unsigned long testFilledCircles(uint8_t radius, uint16_t color) {
+  unsigned long start;
+  int x, y, w = tft.width(), h = tft.height(), r2 = radius * 2;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (x = radius; x < w; x += r2) {
+    for (y = radius; y < h; y += r2) {
+      tft.fillCircle(x, y, radius, color);
+    }
+  }
+
+  return micros() - start;
+}
+
+unsigned long testCircles(uint8_t radius, uint16_t color) {
+  unsigned long start;
+  int           x, y, r2 = radius * 2,
+                      w = tft.width()  + radius,
+                      h = tft.height() + radius;
+
+  // Screen is not cleared for this one -- this is
+  // intentional and does not affect the reported time.
+  start = micros();
+  for (x = 0; x < w; x += r2) {
+    for (y = 0; y < h; y += r2) {
+      tft.drawCircle(x, y, radius, color);
+    }
+  }
+
+  return micros() - start;
+}
+
+unsigned long testTriangles() {
+  unsigned long start;
+  int           n, i, cx = tft.width()  / 2 - 1,
+                      cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  n     = min(cx, cy);
+  start = micros();
+  for (i = 0; i < n; i += 5) {
+    tft.drawTriangle(
+      cx    , cy - i, // peak
+      cx - i, cy + i, // bottom left
+      cx + i, cy + i, // bottom right
+      tft.color565(0, 0, i));
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledTriangles() {
+  unsigned long start, t = 0;
+  int           i, cx = tft.width()  / 2 - 1,
+                   cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (i = min(cx, cy); i > 10; i -= 5) {
+    start = micros();
+    tft.fillTriangle(cx, cy - i, cx - i, cy + i, cx + i, cy + i,
+                     tft.color565(0, i, i));
+    t += micros() - start;
+    tft.drawTriangle(cx, cy - i, cx - i, cy + i, cx + i, cy + i,
+                     tft.color565(i, i, 0));
+  }
+
+  return t;
+}
+
+unsigned long testRoundRects() {
+  unsigned long start;
+  int           w, i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  w     = min(tft.width(), tft.height());
+  start = micros();
+  for (i = 0; i < w; i += 6) {
+    i2 = i / 2;
+    tft.drawRoundRect(cx - i2, cy - i2, i, i, i / 8, tft.color565(i, 0, 0));
+  }
+
+  return micros() - start;
+}
+
+unsigned long testFilledRoundRects() {
+  unsigned long start;
+  int           i, i2,
+                cx = tft.width()  / 2 - 1,
+                cy = tft.height() / 2 - 1;
+
+  tft.fillScreen(TFT_BLACK);
+  start = micros();
+  for (i = min(tft.width(), tft.height()); i > 20; i -= 6) {
+    i2 = i / 2;
+    tft.fillRoundRect(cx - i2, cy - i2, i, i, i / 8, tft.color565(0, i, 0));
+  }
+
+  return micros() - start;
+}

--- a/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/LovyanGFX_CYD_Settings.h
+++ b/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/LovyanGFX_CYD_Settings.h
@@ -1,0 +1,138 @@
+//----------------------------------------------------------------------
+// LovyanGFX_CYD_Settings.h
+// ========================
+// This is a Lovyan settings file that works with my CYD board.
+// I have heavily edited down the original settings file to clear out
+// lots of unnecessary comments (that were in Japanese anyway).
+//----------------------------------------------------------------------
+
+class LGFX : public lgfx::LGFX_Device
+{
+  // Type of panel you want to connect - the CYD uses an ILI9341
+  lgfx::Panel_ILI9341 _panel_instance;
+
+  // Type of bus - the CYD uses HSPI for the display
+  lgfx::Bus_SPI _bus_instance;
+
+  // Enable backlight control - pin 21 on the CYD
+  lgfx::Light_PWM _light_instance;
+
+  // Type of touchscreen type - the CYD uses an XPT2046
+  lgfx::Touch_XPT2046 _touch_instance;
+
+public:
+
+  // Constructor
+  LGFX(void)
+  {
+    // Configure the display SPI bus settings
+    {
+      auto cfg = _bus_instance.config();
+
+      cfg.spi_host = HSPI_HOST; // The CYD uses HSPI for the display
+      cfg.spi_mode = 0; // Don't know what this does
+      // I found the following settings in the Internet. I don't know if they are optimal.
+      cfg.freq_write = 55000000;
+      cfg.freq_read  = 16000000;
+      cfg.spi_3wire  = false; // Set to true if receiving is done on the MOSI pin
+      cfg.use_lock   = true;  // Set to true if you want to use transaction locking
+      // With the ESP-IDF version upgrade, SPI_DMA_CH_AUTO (automatic setting) is now recommended for the DMA channel. Specifying 1ch or 2ch is no longer recommended.
+      cfg.dma_channel = SPI_DMA_CH_AUTO;
+      // HSPI GPIO pins on the CYD
+      cfg.pin_sclk = 14;
+      cfg.pin_mosi = 13;
+      cfg.pin_miso = 12;
+      cfg.pin_dc = 2;
+
+      // Set the config
+      _bus_instance.config(cfg);
+      // Place the bus on the panel
+      _panel_instance.setBus(&_bus_instance);
+    }
+
+    // Configure the display panel control settings
+    {
+      auto cfg = _panel_instance.config();
+
+      cfg.pin_cs = 15;
+      cfg.pin_rst = -1; // -1 = disable
+      cfg.pin_busy = -1; // -1 = disable
+
+      // I had to change the usual ILI9341 dimensions
+      // cfg.panel_width = 240;
+      // cfg.panel_height = 320;
+      cfg.panel_width = 320;
+      cfg.panel_height = 240;
+      cfg.offset_x         =     0;
+      cfg.offset_y         =     0;
+      // On the CYD rotations 0 to 3 are mirrored so use 4 to 7
+      cfg.offset_rotation  =     0;
+      cfg.dummy_read_pixel =     8;  // Number of dummy read bits before pixel readout
+      cfg.dummy_read_bits  =     1;  // Number of dummy read bits before reading non-pixel data
+      cfg.readable         =  true;  // Set to true if data can be read
+      cfg.invert           = false;  // Set to true if the panel's brightness is reversed
+      // On my CYD red and blue were indeed swapped
+      // cfg.rgb_order        = false;  // Set to true if the red and blue of the panel are swapped
+      cfg.rgb_order        = true;  // Set to true if the red and blue of the panel are swapped
+      cfg.dlen_16bit       = false;  // Set to true for panels that transmit data in 16-bit units via 16-bit parallel or SPI
+      // If the bus is shared with the SD card, set it to true (bus control is performed using drawJpgFile, etc.)
+      cfg.bus_shared       =  true;
+
+      // These don't normally need changing but on the CYD I had to change them to get it to work
+      // cfg.memory_width     =   240;
+      // cfg.memory_height    =   320;
+      cfg.memory_width     =   320;
+      cfg.memory_height    =   240;
+
+      // Set the config
+      _panel_instance.config(cfg);
+    }
+
+    // Set the backlight control - comment out if not required
+    {
+      auto cfg = _light_instance.config();
+
+      cfg.pin_bl = 21;
+      cfg.invert = false;  // true if the backlight brightness is inverted
+      cfg.freq   = 44100;  // Backlight PWM frequency
+      cfg.pwm_channel = 7; // PWM channel number to use
+
+      // Set the config
+      _light_instance.config(cfg);
+      // Place the backlight on the panel
+      _panel_instance.setLight(&_light_instance);
+    }
+
+    // Configure touchscreen control - comment out if not needed
+    {
+      auto cfg = _touch_instance.config();
+
+      // Touchscreen limits
+      cfg.x_min = 0;
+      cfg.x_max = 239;
+      cfg.y_min = 0;
+      cfg.y_max = 319;
+
+      cfg.pin_int = -1; // Interrupt GPIO pin, -1 = disable
+      cfg.bus_shared = true; // If you are using a bus that is common with the screen, set it to true
+      cfg.offset_rotation = 0; // Adjust if display and touch direction do not match. Set a value between 0 and 7.
+
+      cfg.spi_host = VSPI_HOST; // The CYD uses VSPI for the touchscreen
+      cfg.freq = 1000000;
+
+      // VSPI GPIO pins on the CYD
+      cfg.pin_sclk = 25;
+      cfg.pin_mosi = 32;
+      cfg.pin_miso = 39;
+      cfg.pin_cs   = 33;
+
+      // Set the config
+      _touch_instance.config(cfg);
+      // Place the touchscreen on the panel
+      _panel_instance.setTouch(&_touch_instance);
+    }
+
+    // Apply all the above settings to the panel
+    setPanel(&_panel_instance);
+  }
+};

--- a/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/README.md
+++ b/Examples/AlternativeLibraries/LovyanGFX/1-LovyanGFX/README.md
@@ -1,0 +1,7 @@
+# 3-LovyanGFX
+
+This is adapted from the speed test sketch provided as an example in the TFT_eSPI library, which was itself adapted from the Adafruit speed test sketch. I have modified the code so it can be compiled with the LovyanGFX library.
+
+The hard bit of using Lovyan is writing the header file for your board. The file I have included works with my CYD, which I think is pretty standard as CYDs go.
+
+I find the Lovyan library is about 10% faster than TFT_eSPI.


### PR DESCRIPTION
These are the TFT_eSPI test code modified to work with the Lovyan and Adafruit libraries.

The existing Adafruit example uses software SPI and that is very slow. The example here shows how to use hardware SPI, which is only about 50% slower than TFT_eSPI.