### PR TITLE
ESPHome example 2-ESPHomeClock fix rotation

### DIFF
--- a/Examples/ESPHome/2-ESPHomeClock/yellowtft1.yaml
+++ b/Examples/ESPHome/2-ESPHomeClock/yellowtft1.yaml
@@ -141,6 +141,9 @@ display:
     cs_pin: GPIO15
     dc_pin: GPIO2
     color_palette: 8BIT # Fix memory issues with ESPHome 25.x
+    dimensions:
+      height: 240
+      width: 320
     transform:
       swap_xy: true
     invert_colors: false


### PR DESCRIPTION
Fix 90-degree screen rotation configuration.

For rotating the display by 80 degrees in hardware, we need also to configure the `dimensions` variable in addition to `transform>swap_xy`. Cf.,
https://esphome.io/components/display/ili9xxx/#configuration-variables

## Testing

Tested on CYD hardware.

Before the change:

<img width="4032" height="3024" alt="before" src="https://github.com/user-attachments/assets/59e85456-1ee1-42f2-bddf-684dc349adf5" />

After the change:

<img width="4032" height="3024" alt="after" src="https://github.com/user-attachments/assets/9a01eaeb-85f7-4f80-8c49-155a7984fc30" />
