### PR TITLE
Add CYD ZX Spectrum project entry

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -45,6 +45,7 @@ Projects appearing on here is not necessarily a seal of approval from me, I will
 | Navi Phone | Relica of the Mobile Phones used int the anime Serial Experments Lain | [Aquafrostbyte](https://github.com/AquaFrostByte) (#) | A Sd card is required, Speaker and Wifi is optional | [Github](https://github.com/AquaFrostByte/Navi-Phone) | |
 | OASMan | Open-source Air Suspension Management - Worlds first DIY Digital Air suspension controller for your car! | [gopro_2027](https://github.com/gopro2027/) | Ideally you would build the manifold and install it in your car, but if you just want to test the connection you can use an original esp32 dev board and flash the manifold code through platformio. We also have a [3d printable case](https://github.com/gopro2027/ArduinoAirSuspensionController/blob/main/3d%20Prints/other/3.2%20inch%20screen%20case/3.2%20inch%20CYD%20screen%20container%20v19%20-%20gopro_2027's%20design.stl) | [Github](https://github.com/gopro2027/ArduinoAirSuspensionController) | [Webflash](https://oasman.dev/oasman/flash/) |
 | Sonos Remote Control | Use your Sonos Speakers as Internet Radio with Station Buttons | Florian Lenz | https://github.com/SpringTideSystems | [GitHub](https://github.com/SpringTideSystems/CYD_Sonos-RemoteControl) | |
+| CYD ZX Spectrum | Turns a CYD into a 48K ZX Spectrum with an on-screen touch keyboard | [Keir Finlow-Bates](https://www.linkedin.com/in/keirf/) | | [Github](https://github.com/kf106/cyd-zxspectrum) | [Webflash](https://kf106.github.io/cyd-zxspectrum/) |
 
 (\#) = Project not added by original author
 


### PR DESCRIPTION
Added an extra line to the PROJECTS.md table for a project  providing a working 48k ZX Spectrum  emulator with usable on-screen keyboard.