### PR TITLE
Add link to Spanish (Español) documentation translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Please note: I can't gaurantee the accuracy of the translation, how up to date t
 
 - [French / Française](https://github.com/usini/ESP32-Cheap-Yellow-Display-Documentation-FR)
 - [German / Deutsch](https://github.com/paelzer/ESP32-Cheap-Yellow-Display-Documentation-DE)
+- [Spanish / Español](https://github.com/chemazener/ESP32-Cheap-Yellow-Display-Documentation-ES)
 
 If you would like to contribure a translation, please name the repo with the language name or code in the repo name and you can link it here.
 


### PR DESCRIPTION
Adds a link in the **Other Languages** section to a community Spanish (es-ES) translation of the documentation, following the convention in the README (separate repo, linked here).

Translation repo: https://github.com/chemazener/ESP32-Cheap-Yellow-Display-Documentation-ES

It covers README, SETUP, PINS, TROUBLESHOOTING, ADDONS, PROJECTS, MEDIA, Mods, 3dModels, Variants and the Example READMEs. A note at the top marks it as a community translation that may lag behind the original.